### PR TITLE
Improved API

### DIFF
--- a/Assets/General/BehaviorTree/Inverter.cs
+++ b/Assets/General/BehaviorTree/Inverter.cs
@@ -12,31 +12,28 @@ namespace BehaviorTree
         /// Evaluate the node
         /// </summary>
         /// <returns>Return SUCCESS if a child node failed, FAILURE if a child node succeeded, or RUNNING</returns>
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             var anyChildIsRunning = false;
 
             foreach (var node in Children)
             {
-                switch (node.Evaluate())
+                node.Evaluate();
+                switch (node.State)
                 {
                     case NodeState.FAILURE:
-                        State = NodeState.SUCCESS;
-                        return State;
+                        return NodeState.SUCCESS;
                     case NodeState.SUCCESS:
-                        State = NodeState.FAILURE;
-                        return State;
+                        return NodeState.FAILURE;
                     case NodeState.RUNNING:
                         anyChildIsRunning = true;
                         break;
                     default:
-                        State = NodeState.FAILURE;
-                        return State;
+                        return NodeState.FAILURE;
                 }
             }
 
-            State = anyChildIsRunning ? NodeState.RUNNING : NodeState.SUCCESS;
-            return State;
+            return anyChildIsRunning ? NodeState.RUNNING : NodeState.SUCCESS;
         }
     }
 }

--- a/Assets/General/BehaviorTree/Inverter.cs
+++ b/Assets/General/BehaviorTree/Inverter.cs
@@ -2,10 +2,10 @@
 
 namespace BehaviorTree
 {
-    [VisualNode]
     /// <summary>
     /// Inverts the result of the child node.
     /// </summary>
+    [VisualNode]
     public class Inverter : Node
     {
         /// <summary>

--- a/Assets/General/BehaviorTree/Node.cs
+++ b/Assets/General/BehaviorTree/Node.cs
@@ -44,7 +44,7 @@ namespace BehaviorTree
         /// <summary>
         /// Current state of the node
         /// </summary>
-        public NodeState State { get; set; }
+        public NodeState State { get; private set; }
 
         #endregion
 
@@ -125,6 +125,14 @@ namespace BehaviorTree
         }
 
         /// <summary>
+        /// Triggers the evaluation of the node
+        /// </summary>
+        public void Evaluate()
+        {
+            State = OnEvaluate();
+        }
+
+        /// <summary>
         /// Adds data to the dictionary
         /// </summary>
         /// <param name="key">Key to be added</param>
@@ -136,18 +144,18 @@ namespace BehaviorTree
 
         #endregion
 
-        #region Public Overrideable Methods
+        #region Protected Overrideable Methods
 
         /// <summary>
         /// Evaluate children node
         /// </summary>
         /// <returns>Return FAILURE by default</returns>
-        public virtual NodeState Evaluate() => NodeState.FAILURE;
+        protected virtual NodeState OnEvaluate() => NodeState.FAILURE;
 
         /// <summary>
         /// Fired on tree initialization
         /// </summary>
-        public virtual void OnInitialized() { }
+        protected virtual void OnInitialized() { }
 
         #endregion
 

--- a/Assets/General/BehaviorTree/Selector.cs
+++ b/Assets/General/BehaviorTree/Selector.cs
@@ -12,27 +12,25 @@ namespace BehaviorTree
         /// Evaluate the node
         /// </summary>
         /// <returns>Return SUCCESS if a child node succeeded, RUNNING if a child node is running, or FAILURE after every evaluated children </returns>
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             foreach (var node in Children)
             {
-                switch (node.Evaluate())
+                node.Evaluate();
+                switch (node.State)
                 {
                     case NodeState.FAILURE:
                         continue;
                     case NodeState.SUCCESS:
-                        State = NodeState.SUCCESS;
-                        return State;
+                        return NodeState.SUCCESS;
                     case NodeState.RUNNING:
-                        State = NodeState.RUNNING;
-                        return State;
+                        return NodeState.RUNNING;
                     default:
                         continue;
                 }
             }
 
-            State = NodeState.FAILURE;
-            return State;
+            return NodeState.FAILURE;
         }
     }
 }

--- a/Assets/General/BehaviorTree/Sequence.cs
+++ b/Assets/General/BehaviorTree/Sequence.cs
@@ -12,30 +12,28 @@ namespace BehaviorTree
         /// Evaluate the node
         /// </summary>
         /// <returns>Return FAILURE if a child node failed, RUNNING if a child is running after every evaluated node, SUCCESS if none of the child is running or failing </returns>
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             var anyChildIsRunning = false;
 
             foreach (var node in Children)
             {
-                switch (node.Evaluate())
+                node.Evaluate();
+                switch (node.State)
                 {
                     case NodeState.FAILURE:
-                        State = NodeState.FAILURE;
-                        return State;
+                        return NodeState.FAILURE;
                     case NodeState.SUCCESS:
                         continue;
                     case NodeState.RUNNING:
                         anyChildIsRunning = true;
                         break;
                     default:
-                        State = NodeState.SUCCESS;
-                        return State;
+                        return NodeState.SUCCESS;
                 }
             }
 
-            State = anyChildIsRunning ? NodeState.RUNNING : NodeState.SUCCESS;
-            return State;
+            return anyChildIsRunning ? NodeState.RUNNING : NodeState.SUCCESS;
         }
     }
 }

--- a/Assets/Infiltration/Scripts/AI/Checks/CheckEnemyInFOVRange.cs
+++ b/Assets/Infiltration/Scripts/AI/Checks/CheckEnemyInFOVRange.cs
@@ -14,12 +14,12 @@ namespace Infiltration
 
         private SpriteRenderer _renderer;
 
-        public override void OnInitialized()
+        protected override void OnInitialized()
         {
             this._renderer = this.Agent.GetComponent<GuardSceneData>().FieldOfView;
         }
 
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             var target = GetData<Transform>("target");
 
@@ -29,8 +29,7 @@ namespace Infiltration
                 {
                     RemoveData("target");
                     _renderer.color = Color.blue;
-                    State = NodeState.FAILURE;
-                    return State;
+                    return NodeState.FAILURE;
                 }
             }
 
@@ -45,16 +44,13 @@ namespace Infiltration
                 {
                     this.Root.SetData("target", colliders[0].transform);
                     _renderer.color = Color.red;
-                    State = NodeState.SUCCESS;
-                    return State;
+                    return NodeState.SUCCESS;
                 }
 
-                State = NodeState.FAILURE;
-                return State;
+                return NodeState.FAILURE;
             }
 
-            State = NodeState.SUCCESS;
-            return State;
+            return NodeState.SUCCESS;
         }
     }
 }

--- a/Assets/Infiltration/Scripts/AI/Checks/CheckEnemyInRange.cs
+++ b/Assets/Infiltration/Scripts/AI/Checks/CheckEnemyInRange.cs
@@ -10,24 +10,21 @@ namespace Infiltration
         [ExposedInVisualEditor]
         public float AttackRange { get; set; }
 
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             var target = this.GetData<Transform>("target");
 
             if (target == null)
             {
-                State = NodeState.FAILURE;
-                return State;
+                return NodeState.FAILURE;
             }
 
             if (Vector3.Distance(this.Agent.transform.position, target.position) <= AttackRange)
             {
-                State = NodeState.SUCCESS;
-                return State;
+                return NodeState.SUCCESS;
             }
 
-            State = NodeState.FAILURE;
-            return State;
+            return NodeState.FAILURE;
         }
     }
 }

--- a/Assets/Infiltration/Scripts/AI/Checks/CheckGameState.cs
+++ b/Assets/Infiltration/Scripts/AI/Checks/CheckGameState.cs
@@ -6,16 +6,14 @@ namespace Infiltration
     [VisualNode]
     public class CheckGameState : Node
     {
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             if (GameManager.StateSet)
             {
-                State = NodeState.FAILURE;
-                return State;
+                return NodeState.FAILURE;
             }
 
-            State = NodeState.SUCCESS;
-            return State;
+            return NodeState.SUCCESS;
         }
     }
 }

--- a/Assets/Infiltration/Scripts/AI/Tasks/TaskAttackPlayer.cs
+++ b/Assets/Infiltration/Scripts/AI/Tasks/TaskAttackPlayer.cs
@@ -10,7 +10,7 @@ namespace Infiltration
         [ExposedInVisualEditor]
         public float AttackRange { get; set; }
 
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             var target = this.GetData<Transform>("target");
 
@@ -20,8 +20,7 @@ namespace Infiltration
                 player.GetHit();
             }
 
-            State = NodeState.RUNNING;
-            return State;
+            return NodeState.RUNNING;
         }
     }
 }

--- a/Assets/Infiltration/Scripts/AI/Tasks/TaskGoTowardEnemy.cs
+++ b/Assets/Infiltration/Scripts/AI/Tasks/TaskGoTowardEnemy.cs
@@ -10,7 +10,7 @@ namespace Infiltration
         [ExposedInVisualEditor]
         public float Speed { get; set; }
 
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             var target = this.GetData<Transform>("target");
 
@@ -24,8 +24,7 @@ namespace Infiltration
                 this.Agent.transform.LookAt(target);
             }
 
-            State = NodeState.RUNNING;
-            return State;
+            return NodeState.RUNNING;
         }
     }
 }

--- a/Assets/Infiltration/Scripts/AI/Tasks/TaskPatrol.cs
+++ b/Assets/Infiltration/Scripts/AI/Tasks/TaskPatrol.cs
@@ -18,12 +18,12 @@ namespace Infiltration
         private float _waitCounter;
         private bool _waiting;
 
-        public override void OnInitialized()
+        protected override void OnInitialized()
         {
             this._waypoints = this.Agent.GetComponent<GuardSceneData>().Waypoints;
         }
 
-        public override NodeState Evaluate()
+        protected override NodeState OnEvaluate()
         {
             if (_waiting)
             {
@@ -52,8 +52,7 @@ namespace Infiltration
                 }
             }
 
-            State = NodeState.RUNNING;
-            return State;
+            return NodeState.RUNNING;
         }
     }
 }


### PR DESCRIPTION
This PR improves the use of `Node.Evaluate` (now `Node.OnEvaluate`) to not have to both set the `State` and return the value.
It now uses the same pattern as `Measure`/`MeasureOverride` in WPF with a call stack that will look like that:
```cs
Node.Evaluate()
Selector.OnEvaluate()
Node.Evaluate()
MyNode1.OnEvaluate()
Node.Evaluate()
MyNode2.OnEvaluate()
etc.
```